### PR TITLE
Do not fetch contao-modules

### DIFF
--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -97,7 +97,6 @@ class Indexer
         } else {
             $packageNames = array_unique(array_merge(
                 $this->packagist->getPackageNames('contao-bundle'),
-                $this->packagist->getPackageNames('contao-module'),
                 $this->packagist->getPackageNames('contao-component')
             ));
         }


### PR DESCRIPTION
I was wondering if this can be removed safely?