### PR TITLE
Filter out dev versions

### DIFF
--- a/src/Package/Factory.php
+++ b/src/Package/Factory.php
@@ -121,6 +121,10 @@ class Factory
     private function isSupported(array $versionsData): bool
     {
         foreach ($versionsData as $version => $versionData) {
+            if (0 === strpos($version, 'dev-')) {
+                continue;
+            }
+
             if ('contao-component' === $versionData['type']) {
                 return true;
             }


### PR DESCRIPTION
The Package Indexer should exclude packages that do not request contao/core-bundle in a stable version.